### PR TITLE
Some of the 'conp' command's output was accidentally in inverse video…

### DIFF
--- a/doc/Davex Xtn.rtf
+++ b/doc/Davex Xtn.rtf
@@ -62,7 +62,7 @@ commands may also have filetype BIN\hich\af2\dbch\af11\loch\f2 .)
 \hich\af2\dbch\af11\loch\f2 Version \hich\af2\dbch\af11\loch\f2 3.4\hich\af2\dbch\af11\loch\f2 ) (\hich\af2\dbch\af11\loch\f2 1\hich\af2\dbch\af11\loch\f2  byte\hich\af2\dbch\af11\loch\f2 )
 \par \hich\af2\dbch\af11\loch\f2          (\hich\af2\dbch\af11\loch\f2 recommended\hich\af2\dbch\af11\loch\f2 :  \hich\af2\dbch\af11\loch\f2 use versions less than \hich\af2\dbch\af11\loch\f2 1.0\hich\af2\dbch\af11\loch\f2  for in\hich\af2\dbch\af11\loch\f2 
 complete versions\hich\af2\dbch\af11\loch\f2 )
-\par \hich\af2\dbch\af11\loch\f2 $\hich\af2\dbch\af11\loch\f2 xx    mimimum Davex version required \hich\af2\dbch\af11\loch\f2 (\hich\af2\dbch\af11\loch\f2 1\hich\af2\dbch\af11\loch\f2  byte\hich\af2\dbch\af11\loch\f2 )
+\par \hich\af2\dbch\af11\loch\f2 $\hich\af2\dbch\af11\loch\f2 xx    minimum Davex version required \hich\af2\dbch\af11\loch\f2 (\hich\af2\dbch\af11\loch\f2 1\hich\af2\dbch\af11\loch\f2  byte\hich\af2\dbch\af11\loch\f2 )
 \par \hich\af2\dbch\af11\loch\f2          (\hich\af2\dbch\af11\loch\f2 use the version number for the Davex you are working with\hich\af2\dbch\af11\loch\f2 , \hich\af2\dbch\af11\loch\f2 unless you\hich\af2\dbch\af11\loch\f2 '\hich\af2\dbch\af11\loch\f2 
 re sure your command works with earlier versions\hich\af2\dbch\af11\loch\f2 )  [\hich\af2\dbch\af11\loch\f2 see auxiliary version nibble below\hich\af2\dbch\af11\loch\f2 ]
 \par \hich\af2\dbch\af11\loch\f2 $\hich\af2\dbch\af11\loch\f2 xx    command characteristics \hich\af2\dbch\af11\loch\f2 (\hich\af2\dbch\af11\loch\f2 1\hich\af2\dbch\af11\loch\f2  byte\hich\af2\dbch\af11\loch\f2 )

--- a/src/common/2/Apple.Globals2.asm
+++ b/src/common/2/Apple.Globals2.asm
@@ -25,7 +25,7 @@ kbuff		= $200
 reset		= $3f2
 
 ;
-; Hardwae locations
+; Hardware locations
 ;
 keyboard	= $c000
 off80col	= $c00c

--- a/src/xtn/2/conp.asm
+++ b/src/xtn/2/conp.asm
@@ -944,7 +944,7 @@ print_ay:	;x=field width (right just)
 	tax
 	bcc pr0
 	beq pr0
-pr1:	lda #' '
+pr1:	lda #_' '
 	jsr cout
 	dex
 	bne pr1
@@ -1091,15 +1091,15 @@ prBits:
 	lsr a
 	clc
 	adc #5
-	ora #'0'
+	ora #_'0'
 	jsr cout
-	lda #'/'
+	lda #_'/'
 	jsr cout
 	pla
 	and #1
 	clc
 	adc #1
-	ora #'0'
+	ora #_'0'
 	jmp cout
 ;
 prBaud:
@@ -1252,12 +1252,12 @@ prColor:
 	pha
 	cmp #10
 	bcs ColNoSp
-	lda #' '
+	lda #_' '
 	jsr cout
 ColNoSp:	pla
 	pha
 	jsr prInt
-	lda #' '
+	lda #_' '
 	jsr cout
 	jsr cout
 	pla
@@ -1319,7 +1319,7 @@ mult32:	asl a
 	tay
 	lda myTemp
 	jsr xprdec_2	;AX=2-byte #
-	lda #'K'
+	lda #_'K'
 	jmp cout
 ;*********************************************
 ;

--- a/src/xtn/2/setstart.asm
+++ b/src/xtn/2/setstart.asm
@@ -85,7 +85,7 @@ just_looking:
 	asc "Startup path is "
 	.byte '"'
 	.byte 0
-	lda #>pagebuff+6
+	lda #>(pagebuff+6)
 	ldy #<pagebuff+6
 	jsr xprint_path
 	jsr xmess

--- a/src/xtn/2/what.asm
+++ b/src/xtn/2/what.asm
@@ -951,7 +951,7 @@ check_alias8:
 	asc "   sysalias for "
 	.byte $A2
 	.byte 0
-	lda #>filebuff2+$E5
+	lda #>(filebuff2+$E5)
 	ldy #<filebuff2+$E5
 	jsr xprint_path
 	jsr xmess


### PR DESCRIPTION
…. Set the high bits of the characters fed to cout.

This is using the "_" macro to get a high-bit-on character, as defined in Macros.asm. I don't see that macro used anywhere else in the source, and I don't know who originally defined it, but it seems reasonably compact. (If it's too obscure, we can do "|$80" instead.)